### PR TITLE
Unrealm readme fix - SPM branch instruction correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ You can also use Swift Package Manager to add Unrealm as a dependency to your pr
 ```bash
 https://github.com/arturdev/Unrealm.git
 ```
-You need to use "SPM" branch instead of master.
+You need to use "master" branch instead of SPM.
 ## ToDos
 
 - Add more UnitTests


### PR DESCRIPTION
XCode 13 throws the SortDescriptor issue on "SPM" Branch. master branch already has Package.swift file enabling it for SPM