### PR TITLE
Rename realm-cocoa to realm-swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .library(name: "Unrealm", targets: ["Unrealm", "UnrealmObjC"])
     ],
     dependencies: [
-        .package(url: "https://github.com/realm/realm-cocoa.git", from: "10.15.1"),
+        .package(url: "https://github.com/realm/realm-swift.git", from: "10.15.1"),
         .package(url: "https://github.com/wickwirew/Runtime.git", from: "2.2.2")
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .library(name: "Unrealm", targets: ["Unrealm", "UnrealmObjC"])
     ],
     dependencies: [
-        .package(url: "https://github.com/realm/realm-swift.git", from: "10.15.1"),
+        .package(url: "https://github.com/realm/realm-swift.git", from: "10.39.0"),
         .package(url: "https://github.com/wickwirew/Runtime.git", from: "2.2.2")
     ],
     targets: [


### PR DESCRIPTION
`realm-cocoa` is old repository name. The current repository name is realm-swift